### PR TITLE
Update pyarrow, removing deprecated methods, and make it compatible with jupyter server 2

### DIFF
--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -xe
 
+pip install -U pip
 pip install notebook pyarrow pytest nose flake8
 
 cd ~/hdfscm

--- a/continuous_integration/runtests.sh
+++ b/continuous_integration/runtests.sh
@@ -3,6 +3,6 @@ set -xe
 
 cd hdfscm
 export CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath --glob`
-export JUPYTER_ENV=dev
+export JUPYTER_ENV=test
 py.test hdfscm --verbose
 flake8 hdfscm

--- a/continuous_integration/runtests.sh
+++ b/continuous_integration/runtests.sh
@@ -2,5 +2,6 @@
 set -xe
 
 cd hdfscm
+export CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath --glob`
 py.test hdfscm --verbose
 flake8 hdfscm

--- a/continuous_integration/runtests.sh
+++ b/continuous_integration/runtests.sh
@@ -3,5 +3,6 @@ set -xe
 
 cd hdfscm
 export CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath --glob`
+export JUPYTER_ENV=dev
 py.test hdfscm --verbose
 flake8 hdfscm

--- a/hdfscm/checkpoints.py
+++ b/hdfscm/checkpoints.py
@@ -2,10 +2,10 @@ import hashlib
 import os
 import posixpath
 
-if 'JUPYTER_SERVER_ROOT' in os.environ:
-    from jupyter_server.services.contents.checkpoints import Checkpoints
-else:
+if os.getenv('JUPYTER_ENV') == 'dev':
     from notebook.services.contents.checkpoints import Checkpoints
+else:
+    from jupyter_server.services.contents.checkpoints import Checkpoints
 from pyarrow import fs
 from tornado.web import HTTPError
 from traitlets import Unicode, Instance, default

--- a/hdfscm/checkpoints.py
+++ b/hdfscm/checkpoints.py
@@ -1,12 +1,12 @@
 import hashlib
 import posixpath
+
 from notebook.services.contents.checkpoints import Checkpoints
+from pyarrow import hdfs
 from tornado.web import HTTPError
 from traitlets import Unicode, Instance, default
-from pyarrow import hdfs
 
-from .utils import to_fs_path, perm_to_403, get_prefix_from_fs_path, get_prefix_from_hdfs_path, utcfromtimestamp, utcnow
-
+from .utils import to_fs_path, perm_to_403, get_prefix_from_fs_path, utcfromtimestamp, utcnow
 
 __all__ = ('HDFSCheckpoints', 'NoOpCheckpoints')
 

--- a/hdfscm/checkpoints.py
+++ b/hdfscm/checkpoints.py
@@ -2,7 +2,7 @@ import hashlib
 import posixpath
 
 from notebook.services.contents.checkpoints import Checkpoints
-from pyarrow import hdfs
+from pyarrow import fs
 from tornado.web import HTTPError
 from traitlets import Unicode, Instance, default
 
@@ -50,7 +50,7 @@ class HDFSCheckpoints(Checkpoints):
         """
     )
 
-    fs = Instance(hdfs.HadoopFileSystem)
+    fs = Instance(fs.HadoopFileSystem)
 
     @default('fs')
     def _default_fs(self):
@@ -72,7 +72,7 @@ class HDFSCheckpoints(Checkpoints):
     def rename_checkpoint(self, checkpoint_id, old_path, new_path):
         old_cp_path = self._checkpoint_path(checkpoint_id, old_path)
         new_cp_path = self._checkpoint_path(checkpoint_id, new_path)
-        if self.fs.isfile(old_cp_path):
+        if self._is_file(old_cp_path):
             self.log.debug("Renaming checkpoint %s -> %s",
                            old_cp_path, new_cp_path)
             self._rename(old_cp_path, new_cp_path)
@@ -80,7 +80,7 @@ class HDFSCheckpoints(Checkpoints):
     def delete_checkpoint(self, checkpoint_id, path):
         path = path.strip('/')
         cp_path = self._checkpoint_path(checkpoint_id, path)
-        if not self.fs.isfile(cp_path):
+        if not self._is_file(cp_path):
             raise HTTPError(
                 404, 'Checkpoint does not exist: %s@%s' % (path, checkpoint_id)
             )
@@ -90,15 +90,15 @@ class HDFSCheckpoints(Checkpoints):
     def list_checkpoints(self, path):
         path = path.strip('/')
         cp_path = self._checkpoint_path(CHECKPOINT_ID, path)
-        if not self.fs.isfile(cp_path):
+        if not self._is_file(cp_path):
             return []
         else:
             return [self._checkpoint_model(CHECKPOINT_ID, cp_path)]
 
     def _checkpoint_model(self, checkpoint_id, hdfs_path):
         with perm_to_403(hdfs_path):
-            info = self.fs.info(hdfs_path)
-        last_modified = utcfromtimestamp(info['last_modified'])
+            info = self.fs.get_file_info(hdfs_path)
+        last_modified = utcfromtimestamp(info.mtime)
         return {'id': checkpoint_id,
                 'last_modified': last_modified}
 
@@ -115,23 +115,21 @@ class HDFSCheckpoints(Checkpoints):
         )
         cp_dir = posixpath.join(self.parent.root_dir, self.checkpoint_dir)
         with perm_to_403(cp_dir):
-            self.fs.mkdir(cp_dir)
+            self.fs.create_dir(cp_dir)
         cp_path = posixpath.join(cp_dir, cp_filename)
         return cp_path
 
+    def _is_file(self, hdfs_path):
+        return self.fs.get_file_info(hdfs_path).type == fs.FileType.File
+
     def _copy(self, src_path, dest_path):
-        # TODO: pyarrow.hdfs currently doesn't implement copy, so this is
-        # less efficient than it should be.
         with perm_to_403(src_path):
-            with self.fs.open(src_path, 'rb') as source:
-                with perm_to_403(dest_path):
-                    with self.fs.open(dest_path, 'wb') as dest:
-                        dest.upload(source)
+            self.fs.copy_file(src_path, dest_path)
 
     def _rename(self, old, new):
         with perm_to_403(old):
-            self.fs.rename(old, new)
+            self.fs.move(old, new)
 
     def _delete(self, cp_path):
         with perm_to_403(cp_path):
-            self.fs.delete(cp_path)
+            self.fs.delete_file(cp_path)

--- a/hdfscm/checkpoints.py
+++ b/hdfscm/checkpoints.py
@@ -2,7 +2,7 @@ import hashlib
 import os
 import posixpath
 
-if os.getenv('JUPYTER_ENV') == 'dev':
+if os.getenv('JUPYTER_ENV') == 'test':
     from notebook.services.contents.checkpoints import Checkpoints
 else:
     from jupyter_server.services.contents.checkpoints import Checkpoints

--- a/hdfscm/checkpoints.py
+++ b/hdfscm/checkpoints.py
@@ -6,7 +6,7 @@ from pyarrow import fs
 from tornado.web import HTTPError
 from traitlets import Unicode, Instance, default
 
-from .utils import to_fs_path, perm_to_403, get_prefix_from_fs_path, utcfromtimestamp, utcnow
+from .utils import to_fs_path, perm_to_403, get_prefix_from_fs_path, utcnow
 
 __all__ = ('HDFSCheckpoints', 'NoOpCheckpoints')
 
@@ -98,7 +98,6 @@ class HDFSCheckpoints(Checkpoints):
     def _checkpoint_model(self, checkpoint_id, hdfs_path):
         with perm_to_403(hdfs_path):
             info = self.fs.get_file_info(hdfs_path)
-        last_modified = utcfromtimestamp(info.mtime)
         return {'id': checkpoint_id,
                 'last_modified': last_modified}
 

--- a/hdfscm/checkpoints.py
+++ b/hdfscm/checkpoints.py
@@ -1,7 +1,7 @@
 import hashlib
 import posixpath
 
-from notebook.services.contents.checkpoints import Checkpoints
+from jupyter_server.services.contents.checkpoints import Checkpoints
 from pyarrow import fs
 from tornado.web import HTTPError
 from traitlets import Unicode, Instance, default

--- a/hdfscm/checkpoints.py
+++ b/hdfscm/checkpoints.py
@@ -1,7 +1,11 @@
 import hashlib
+import os
 import posixpath
 
-from jupyter_server.services.contents.checkpoints import Checkpoints
+if 'JUPYTER_SERVER_ROOT' in os.environ:
+    from jupyter_server.services.contents.checkpoints import Checkpoints
+else:
+    from notebook.services.contents.checkpoints import Checkpoints
 from pyarrow import fs
 from tornado.web import HTTPError
 from traitlets import Unicode, Instance, default

--- a/hdfscm/checkpoints.py
+++ b/hdfscm/checkpoints.py
@@ -98,6 +98,7 @@ class HDFSCheckpoints(Checkpoints):
     def _checkpoint_model(self, checkpoint_id, hdfs_path):
         with perm_to_403(hdfs_path):
             info = self.fs.get_file_info(hdfs_path)
+        last_modified = info.mtime
         return {'id': checkpoint_id,
                 'last_modified': last_modified}
 

--- a/hdfscm/hdfsmanager.py
+++ b/hdfscm/hdfsmanager.py
@@ -5,10 +5,10 @@ from getpass import getuser
 from typing import List
 
 import nbformat
-if 'JUPYTER_SERVER_ROOT' in os.environ:
-    from jupyter_server.services.contents.manager import ContentsManager
-else:
+if os.getenv('JUPYTER_ENV') == 'dev':
     from notebook.services.contents.manager import ContentsManager
+else:
+    from jupyter_server.services.contents.manager import ContentsManager
 from pyarrow import fs
 from tornado.web import HTTPError
 from traitlets import Unicode, Integer, Bool, default

--- a/hdfscm/hdfsmanager.py
+++ b/hdfscm/hdfsmanager.py
@@ -2,14 +2,13 @@ import mimetypes
 from base64 import encodebytes, decodebytes
 from getpass import getuser
 from typing import List
-from urllib.parse import urlsplit
 
 import nbformat
 from notebook.services.contents.manager import ContentsManager
-from pyarrow import fs, ArrowIOError
+from pyarrow import fs
 from pyarrow._fs import FileType, FileInfo, FileSelector
-from traitlets import Unicode, Integer, Bool, default
 from tornado.web import HTTPError
+from traitlets import Unicode, Integer, Bool, default
 
 from .checkpoints import HDFSCheckpoints
 from .utils import (to_fs_path, to_api_path, is_hidden, perm_to_403,

--- a/hdfscm/hdfsmanager.py
+++ b/hdfscm/hdfsmanager.py
@@ -6,7 +6,6 @@ from typing import List
 import nbformat
 from notebook.services.contents.manager import ContentsManager
 from pyarrow import fs
-from pyarrow._fs import FileType, FileInfo, FileSelector
 from tornado.web import HTTPError
 from traitlets import Unicode, Integer, Bool, default
 
@@ -123,17 +122,17 @@ class HDFSContentsManager(ContentsManager):
         return self.path_exist(hdfs_path)
 
     def is_file(self, hdfs_path):
-        return self.fs.get_file_info(hdfs_path).type == FileType.File
+        return self.fs.get_file_info(hdfs_path).type == fs.FileType.File
 
     def is_dir(self, hdfs_path):
-        return self.fs.get_file_info(hdfs_path).type == FileType.Directory
+        return self.fs.get_file_info(hdfs_path).type == fs.FileType.Directory
 
-    def list_dir(self, hdfs_path, recursive=False) -> List[FileInfo]:
-        return self.fs.get_file_info(FileSelector(hdfs_path, recursive=recursive))
+    def list_dir(self, hdfs_path, recursive=False) -> List[fs.FileInfo]:
+        return self.fs.get_file_info(fs.FileSelector(hdfs_path, recursive=recursive))
 
-    def _info_and_check_kind(self, path, hdfs_path, kind: FileType) -> FileInfo:
+    def _info_and_check_kind(self, path, hdfs_path, kind: fs.FileType) -> fs.FileInfo:
         info = self.fs.get_file_info(hdfs_path)
-        if info.type == FileType.NotFound:
+        if info.type == fs.FileType.NotFound:
             raise HTTPError(404, "%s does not exist: %s"
                             % (kind, path))
 
@@ -141,7 +140,7 @@ class HDFSContentsManager(ContentsManager):
             raise HTTPError(400, "%s is not a %s" % (path, kind))
         return info
 
-    def _model_from_info(self, info: FileInfo, type: str=None):
+    def _model_from_info(self, info: fs.FileInfo, type: str=None):
         hdfs_path = info.path
         timestamp = info.mtime
 
@@ -173,7 +172,7 @@ class HDFSContentsManager(ContentsManager):
         return model
 
     def _dir_model(self, path, hdfs_path, content):
-        info = self._info_and_check_kind(path, hdfs_path, FileType.Directory)
+        info = self._info_and_check_kind(path, hdfs_path, fs.FileType.Directory)
         model = self._model_from_info(info, 'directory')
         if content:
             with perm_to_403(path):
@@ -188,7 +187,7 @@ class HDFSContentsManager(ContentsManager):
         return model
 
     def _file_model(self, path, hdfs_path, content, format):
-        info = self._info_and_check_kind(path, hdfs_path, FileType.File)
+        info = self._info_and_check_kind(path, hdfs_path, fs.FileType.File)
         model = self._model_from_info(info, 'file')
 
         if content:
@@ -207,7 +206,7 @@ class HDFSContentsManager(ContentsManager):
         return model
 
     def _notebook_model(self, path, hdfs_path, content=True):
-        info = self._info_and_check_kind(path, hdfs_path, FileType.File)
+        info = self._info_and_check_kind(path, hdfs_path, fs.FileType.File)
         model = self._model_from_info(info, 'notebook')
 
         if content:
@@ -353,7 +352,7 @@ class HDFSContentsManager(ContentsManager):
         return not files
 
     def path_exist(self, hdfs_path):
-        return self.fs.get_file_info(hdfs_path).type != FileType.NotFound
+        return self.fs.get_file_info(hdfs_path).type != fs.FileType.NotFound
 
     def delete_file(self, path):
         hdfs_path = to_fs_path(path, get_prefix_from_fs_path(path, self.root_dir, self.shared_dir))

--- a/hdfscm/hdfsmanager.py
+++ b/hdfscm/hdfsmanager.py
@@ -1,10 +1,14 @@
 import mimetypes
+import os
 from base64 import encodebytes, decodebytes
 from getpass import getuser
 from typing import List
 
 import nbformat
-from jupyter_server.services.contents.manager import ContentsManager
+if 'JUPYTER_SERVER_ROOT' in os.environ:
+    from jupyter_server.services.contents.manager import ContentsManager
+else:
+    from notebook.services.contents.manager import ContentsManager
 from pyarrow import fs
 from tornado.web import HTTPError
 from traitlets import Unicode, Integer, Bool, default

--- a/hdfscm/hdfsmanager.py
+++ b/hdfscm/hdfsmanager.py
@@ -4,7 +4,7 @@ from getpass import getuser
 from typing import List
 
 import nbformat
-from notebook.services.contents.manager import ContentsManager
+from jupyter_server.services.contents.manager import ContentsManager
 from pyarrow import fs
 from tornado.web import HTTPError
 from traitlets import Unicode, Integer, Bool, default

--- a/hdfscm/hdfsmanager.py
+++ b/hdfscm/hdfsmanager.py
@@ -11,8 +11,7 @@ from traitlets import Unicode, Integer, Bool, default
 
 from .checkpoints import HDFSCheckpoints
 from .utils import (to_fs_path, to_api_path, is_hidden, perm_to_403,
-                    get_prefix_from_fs_path, get_prefix_from_hdfs_path,
-                    utcfromtimestamp)
+                    get_prefix_from_fs_path, get_prefix_from_hdfs_path)
 
 
 class HDFSContentsManager(ContentsManager):
@@ -79,7 +78,7 @@ class HDFSContentsManager(ContentsManager):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.log.debug("Connecting to HDFS at %s:%d",
+        self.log.info("Connecting to HDFS at %s:%d",
                        self.hdfs_host, self.hdfs_port)
         self.fs = fs.HadoopFileSystem(host=self.hdfs_host, port=self.hdfs_port)
         if self.create_root_dir_on_startup:
@@ -148,7 +147,7 @@ class HDFSContentsManager(ContentsManager):
         name = path.rsplit('/', 1)[-1]
 
         if type is None:
-            if self.is_dir(info.type):
+            if info.type == fs.FileType.Directory:
                 type = 'directory'
             elif path.endswith('.ipynb'):
                 type = 'notebook'
@@ -157,7 +156,6 @@ class HDFSContentsManager(ContentsManager):
 
         mimetype = mimetypes.guess_type(path)[0] if type == 'file' else None
         size = info.size if type != 'directory' else None
-        timestamp = utcfromtimestamp(timestamp)
         model = {'name': name,
                  'path': path,
                  'last_modified': timestamp,

--- a/hdfscm/hdfsmanager.py
+++ b/hdfscm/hdfsmanager.py
@@ -5,7 +5,7 @@ from getpass import getuser
 from typing import List
 
 import nbformat
-if os.getenv('JUPYTER_ENV') == 'dev':
+if os.getenv('JUPYTER_ENV') == 'test':
     from notebook.services.contents.manager import ContentsManager
 else:
     from jupyter_server.services.contents.manager import ContentsManager

--- a/hdfscm/hdfsmanager.py
+++ b/hdfscm/hdfsmanager.py
@@ -78,7 +78,7 @@ class HDFSContentsManager(ContentsManager):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.log.info("Connecting to HDFS at %s:%d",
+        self.log.debug("Connecting to HDFS at %s:%d",
                        self.hdfs_host, self.hdfs_port)
         self.fs = fs.HadoopFileSystem(host=self.hdfs_host, port=self.hdfs_port)
         if self.create_root_dir_on_startup:

--- a/hdfscm/tests/test_hdfsmanager.py
+++ b/hdfscm/tests/test_hdfsmanager.py
@@ -14,8 +14,7 @@ class HDFSContentsManagerTestCase(TestContentsManager):
         self.contents_manager = HDFSContentsManager(root_dir=self.root_dir)
 
     def tearDown(self):
-        self.contents_manager.fs.delete(self.root_dir, recursive=True)
-        self.contents_manager.fs.close()
+        self.contents_manager.fs.delete_dir(self.root_dir)
 
     def make_dir(self, api_path):
         self.contents_manager.new(
@@ -31,9 +30,6 @@ class HDFSContentsManagerNoOpCheckpointsTestCase(HDFSContentsManagerTestCase):
             root_dir=self.root_dir,
             checkpoints_class=NoOpCheckpoints
         )
-
-    def tearDown(self):
-        self.contents_manager.fs.close()
 
 
 del TestContentsManager

--- a/hdfscm/tests/test_hdfsmanager_api.py
+++ b/hdfscm/tests/test_hdfsmanager_api.py
@@ -1,6 +1,6 @@
 import nbformat
 from notebook.services.contents.tests.test_contents_api import (
-    APITest, assert_http_error
+    assert_http_error, APITest
 )
 from traitlets.config import Config
 from unicodedata import normalize

--- a/hdfscm/tests/test_hdfsmanager_api.py
+++ b/hdfscm/tests/test_hdfsmanager_api.py
@@ -95,7 +95,7 @@ class HDFSContentsAPITest(APITest):
     def test_list_dirs(self):
         dirs = self.dirs_only(self.api.list().json())
         dir_names = {normalize('NFC', d['name']) for d in dirs}
-        top_level_dirs = self.top_level_dirs | { 'shared' } # adding shared folder to top level folders of APITest
+        top_level_dirs = self.top_level_dirs | {'shared'}  # adding shared folder to top level folders of APITest
         self.assertEqual(dir_names, top_level_dirs)  # Excluding hidden dirs
 
     def test_delete_dirs(self):
@@ -103,7 +103,7 @@ class HDFSContentsAPITest(APITest):
         for name in sorted(self.dirs + ['/'], key=len, reverse=True):
             listing = self.api.list(name).json()['content']
             for model in listing:
-                if model['path'] != 'shared': # Shared folder can't be deleted
+                if model['path'] != 'shared':  # Shared folder can't be deleted
                     self.api.delete(model['path'])
         listing = [file['path'] for file in self.api.list('/').json()['content']]
         expected = ['shared']

--- a/hdfscm/tests/test_hdfsmanager_api.py
+++ b/hdfscm/tests/test_hdfsmanager_api.py
@@ -70,14 +70,16 @@ class HDFSContentsAPITest(APITest):
         hdfs_path = self.get_hdfs_path(api_path)
         if self.fs.get_file_info(hdfs_path).type == fs.FileType.Directory:
             self.fs.delete_dir(hdfs_path)
+        elif self.fs.get_file_info(hdfs_path).type == fs.FileType.File:
+            self.fs.delete_file(hdfs_path)
 
     delete_dir = delete_file
 
     def isfile(self, api_path):
-        return self.fs.isfile(self.get_hdfs_path(api_path))
+        return self.fs.get_file_info(self.get_hdfs_path(api_path)).type == fs.FileType.File
 
     def isdir(self, api_path):
-        return self.fs.isdir(self.get_hdfs_path(api_path))
+        return self.fs.get_file_info(self.get_hdfs_path(api_path)).type == fs.FileType.Directory
 
     # Test overrides.
     def test_checkpoints_separate_root(self):

--- a/hdfscm/utils.py
+++ b/hdfscm/utils.py
@@ -18,10 +18,6 @@ class _utc_tzinfo(tzinfo):
 _UTC = _utc_tzinfo()
 
 
-def utcfromtimestamp(t):
-    return datetime.utcfromtimestamp(t).replace(tzinfo=_UTC)
-
-
 def utcnow():
     return datetime.now().replace(tzinfo=_UTC)
 

--- a/hdfscm/utils.py
+++ b/hdfscm/utils.py
@@ -48,6 +48,25 @@ def is_hidden(fs_path, root):
     path = to_api_path(fs_path, root)
     return any(part.startswith('.') for part in path.split("/"))
 
+def get_prefix_from_fs_path(path, root_dir, shared_dir):
+    """
+    Returns the path prefix for the given path after resolving if it should be
+    served from the global shared dir or personal notebook dir.
+    """
+    if path.strip('/').split('/')[0] == 'shared':
+        return shared_dir
+    else:
+        return root_dir
+
+def get_prefix_from_hdfs_path(path, root_dir, shared_dir):
+    """
+    Returns the path prefix for the given path after resolving if the HDFS dir
+    is a personal notebook dir or the shared dir.
+    """
+    if path.startswith(shared_dir):
+        return shared_dir
+    else:
+        return root_dir
 
 @contextmanager
 def perm_to_403(path):

--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,4 @@ setup(name='jupyter-hdfscm',
                    'Programming Language :: Python :: 3'],
       packages=['hdfscm'],
       python_requires='>=3.5',
-      install_requires=['notebook>=4.0', 'pyarrow>=0.9.0'])
+      install_requires=['notebook>=6.5.4', 'pyarrow>=12.0.0,<13.0.0'])


### PR DESCRIPTION
This PR includes the following changes:
- Update pyarrow to version >=12.0.0 removing deprecated methods
- Make the hdfscm compatible with jupyter_server version >= 2

It was tested with unit tests from `notebook.services.contents.tests` and in a jupyterhub with jupyter server 2.