### PR TITLE
Fix hdfs permissions exception capture during saving file and notebooks.

### DIFF
--- a/hdfscm/utils.py
+++ b/hdfscm/utils.py
@@ -71,5 +71,7 @@ def perm_to_403(path):
     except ArrowIOError as exc:
         # For now we can't access the errno attribute of the error directly,
         # detect it from the string instead.
-        if 'errno: 13 (Permission denied)' in str(exc):
+        if 'Permission denied' in str(exc):
             raise HTTPError(403, 'Permission denied: %s' % path)
+        else:
+            raise HTTPError(500, 'ArrowIOError: %s' % exc)

--- a/hdfscm/utils.py
+++ b/hdfscm/utils.py
@@ -73,5 +73,3 @@ def perm_to_403(path):
         # detect it from the string instead.
         if 'Permission denied' in str(exc):
             raise HTTPError(403, 'Permission denied: %s' % path)
-        else:
-            raise HTTPError(500, 'ArrowIOError: %s' % exc)

--- a/hdfscm/utils.py
+++ b/hdfscm/utils.py
@@ -3,6 +3,7 @@ from datetime import datetime, tzinfo, timedelta
 
 from pyarrow import ArrowIOError
 from tornado.web import HTTPError
+import errno
 
 
 _ZERO = timedelta(0)
@@ -69,7 +70,5 @@ def perm_to_403(path):
     try:
         yield
     except ArrowIOError as exc:
-        # For now we can't access the errno attribute of the error directly,
-        # detect it from the string instead.
-        if 'Permission denied' in str(exc):
+        if exc.errno == errno.EACCES:
             raise HTTPError(403, 'Permission denied: %s' % path)


### PR DESCRIPTION
The text to capture from permission denied is too specific and depending on the hadoop version it can be slightly different:

```
Detail: [errno 13] Permission denied
```

In this PR will only detect the `Permission denied text` to raise the HTTP 403 error.